### PR TITLE
Address is not right when using 0.0.0.0 in windows 10 13

### DIFF
--- a/p2p_test.go
+++ b/p2p_test.go
@@ -5,10 +5,23 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestWindowsPrivetaAddress(t *testing.T) {
+	opts := []Option{
+		HostName("0.0.0.0"),
+		Port(1234),
+	}
+	host, err := NewHost(context.Background(), opts...)
+	require.NoError(t, err)
+	for _,addr:=range host.Addresses(){
+		require.False(t,strings.Contains(addr.String(),disabledIP))
+	}
+}
 
 func TestBroadcast(t *testing.T) {
 	runP2P := func(t *testing.T, options ...Option) {


### PR DESCRIPTION
work on #13
If windows have some diabled network cards,the "169.254" address will be assigned,but those ips cannot connect,so I add a filter to remove those ips,I tested this with iotex-core,all tests passed