### PR TITLE
Add  pubsub Maxmessagesize config

### DIFF
--- a/p2p.go
+++ b/p2p.go
@@ -381,7 +381,7 @@ func NewHost(ctx context.Context, options ...Option) (*Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	ps, err := newPubSub(ctx, host, pubsub.WithBlacklist(blacklist))
+	ps, err := newPubSub(ctx, host, pubsub.WithBlacklist(blacklist), pubsub.WithMaxMessageSize(12582912))
 	if err != nil {
 		return nil, err
 	}

--- a/p2p.go
+++ b/p2p.go
@@ -68,6 +68,7 @@ type (
 		PrivateNetworkPSK        string          `yaml:"privateNetworkPSK"`
 		GroupID                  string          `yaml:"groupID"`
 		MaxPeer                  int             `yaml:"maxPeer"`
+		MaxMessageSize           int             `yaml:"maxMessageSize"`
 		BlacklistTolerance       int             `yaml:"blacklistTolerance"`
 	}
 
@@ -106,6 +107,7 @@ var (
 		ProtocolID:               "/iotex",
 		GroupID:                  "iotex",
 		MaxPeer:                  30,
+		MaxMessageSize:           12582912, // 12MB
 		BlacklistTolerance:       3,
 	}
 
@@ -250,6 +252,14 @@ func WithMaxPeer(num uint32) Option {
 	}
 }
 
+// WithMaxMessageSize config MaxMessageSize option.
+func WithMaxMessageSize(size int) Option {
+	return func(cfg *Config) error {
+		cfg.MaxMessageSize = size
+		return nil
+	}
+}
+
 // Host is the main struct that represents a host that communicating with the rest of the P2P networks
 type Host struct {
 	host           core.Host
@@ -381,7 +391,7 @@ func NewHost(ctx context.Context, options ...Option) (*Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	ps, err := newPubSub(ctx, host, pubsub.WithBlacklist(blacklist), pubsub.WithMaxMessageSize(12582912))
+	ps, err := newPubSub(ctx, host, pubsub.WithBlacklist(blacklist), pubsub.WithMaxMessageSize(cfg.MaxMessageSize))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The default in the original libp2p is `1M`, but the default is `12M` here.